### PR TITLE
fix(npc): reorder readline includes in sdb.cpp

### DIFF
--- a/npc/csrc/monitor/sdb/sdb.cpp
+++ b/npc/csrc/monitor/sdb/sdb.cpp
@@ -14,10 +14,10 @@
  ***************************************************************************************/
 
 #include <math.h>
-#include <readline/readline.h>
-#include <readline/history.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <readline/readline.h>
+#include <readline/history.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>


### PR DESCRIPTION
Reorder readline includes in sdb.cpp, this will fix:
```shell
In file included from /nix/store/xkl7b7vd4d91ra6i49n3myp66kffda8v-readline-8.3p1-dev/include/readline/readline.h:36,
                 from ../../csrc/monitor/sdb/sdb.cpp:17:
/nix/store/xkl7b7vd4d91ra6i49n3myp66kffda8v-readline-8.3p1-dev/include/readline/rltypedefs.h:67:13: error: typedef ‘rl_getc_func_t’ is initialized (use ‘decltype’ instead)
   67 | typedef int rl_getc_func_t (FILE *);
      |             ^~~~~~~~~~~~~~
/nix/store/xkl7b7vd4d91ra6i49n3myp66kffda8v-readline-8.3p1-dev/include/readline/rltypedefs.h:67:29: error: ‘FILE’ was not declared in this scope
   67 | typedef int rl_getc_func_t (FILE *);
      |                             ^~~~
/nix/store/xkl7b7vd4d91ra6i49n3myp66kffda8v-readline-8.3p1-dev/include/readline/rltypedefs.h:1:1: note: ‘FILE’ is defined in header ‘<cstdio>’; this is probably fixable by adding ‘#include <cstdio>’
  +++ |+#include <cstdio>
    1 | /* rltypedefs.h -- Type declarations for readline functions. */
/nix/store/xkl7b7vd4d91ra6i49n3myp66kffda8v-readline-8.3p1-dev/include/readline/rltypedefs.h:67:35: error: expected primary-expression before ‘)’ token
   67 | typedef int rl_getc_func_t (FILE *);
      |                                   ^
/nix/store/xkl7b7vd4d91ra6i49n3myp66kffda8v-readline-8.3p1-dev/include/readline/readline.h:452:21: error: ‘FILE’ was not declared in this scope
  452 | extern int rl_getc (FILE *);
      |                     ^~~~
/nix/store/xkl7b7vd4d91ra6i49n3myp66kffda8v-readline-8.3p1-dev/include/readline/readline.h:39:1: note: ‘FILE’ is defined in header ‘<cstdio>’; this is probably fixable by adding ‘#include <cstdio>’
   38 | #  include <readline/tilde.h>
  +++ |+#include <cstdio>
   39 | #endif
```